### PR TITLE
Use the official release packages to generate tagged releases

### DIFF
--- a/build-wp.sh
+++ b/build-wp.sh
@@ -40,12 +40,6 @@ if [ -d /tmp/wp ]; then
     rm -rf /tmp/wp
 fi
 
-echo "Grabbing WordPress source for $ref"
-revision=$(svn info "https://develop.svn.wordpress.org/$ref/" | grep 'Last Changed Rev' | sed 's/Last Changed Rev: //')
-svn export --ignore-externals "https://develop.svn.wordpress.org/$ref/" /tmp/wp/ > /dev/null 2>&1
-
-pushd /tmp/wp/
-
 exit_on_error(){
     echo "$1"
     if [ $# -gt 2 ]; then
@@ -54,6 +48,12 @@ exit_on_error(){
     fi
     exit $2
 }
+
+echo "Grabbing WordPress source for $ref"
+revision=$(svn info "https://develop.svn.wordpress.org/$ref/" | grep 'Last Changed Rev' | sed 's/Last Changed Rev: //')
+svn export --ignore-externals "https://develop.svn.wordpress.org/$ref/" /tmp/wp/ > /dev/null 2>&1
+
+pushd /tmp/wp/
 
 if [ -e "Gruntfile.js" ]; then
     echo "Installing npm dependencies..."

--- a/build-wp.sh
+++ b/build-wp.sh
@@ -50,6 +50,8 @@ exit_on_error(){
 }
 
 echo "Grabbing WordPress source for $ref"
+if [ "tag" == $type ]; then
+else
 revision=$(svn info "https://develop.svn.wordpress.org/$ref/" | grep 'Last Changed Rev' | sed 's/Last Changed Rev: //')
 svn export --ignore-externals "https://develop.svn.wordpress.org/$ref/" /tmp/wp/ > /dev/null 2>&1
 
@@ -67,6 +69,7 @@ if [ -e "Gruntfile.js" ]; then
 else
     mkdir build
     mv $(ls -A | grep -vE '^build$') build
+fi
 fi
 
 echo "Cloning git repository..."

--- a/build-wp.sh
+++ b/build-wp.sh
@@ -53,23 +53,23 @@ echo "Grabbing WordPress source for $ref"
 revision=$(svn info "https://develop.svn.wordpress.org/$ref/" | grep 'Last Changed Rev' | sed 's/Last Changed Rev: //')
 if [ "tag" == $type ]; then
 else
-svn export --ignore-externals "https://develop.svn.wordpress.org/$ref/" /tmp/wp/ > /dev/null 2>&1
+    svn export --ignore-externals "https://develop.svn.wordpress.org/$ref/" /tmp/wp/ > /dev/null 2>&1
 
-pushd /tmp/wp/
+    pushd /tmp/wp/
 
-if [ -e "Gruntfile.js" ]; then
-    echo "Installing npm dependencies..."
-    sed -i -e 's/97c43554ff7a86e2ff414d34e66725b05118bf10/936144c11fdee00427c3ce3cb0f87ee5770149b7/' package.json
-    sed -i -e 's/~/^/g' package.json
-    cat package.json | jq '.devDependencies."grunt-sass" = if .devDependencies."grunt-sass" | test("\\^0\\.\\d+\\.\\d+") then "^1.0.0" else .devDependencies."grunt-sass" end' > package.nn.json && mv package.nn.json package.json
-    cat package.json | jq '.devDependencies."grunt-contrib-imagemin" = if .devDependencies."grunt-contrib-imagemin" | test("\\^0\\.\\d+\\.\\d+") then "^1.0.0" else .devDependencies."grunt-contrib-imagemin" end' > package.nn.json && mv package.nn.json package.json
-    output="$(npm update --dev 2>&1)" || exit_on_error 'NPM install failed' 3 "$output"
-    echo 'Running grunt...'
-    output="$(grunt)" || exit_on_error 'Grunt failed' 3 "$output"
-else
-    mkdir build
-    mv $(ls -A | grep -vE '^build$') build
-fi
+    if [ -e "Gruntfile.js" ]; then
+        echo "Installing npm dependencies..."
+        sed -i -e 's/97c43554ff7a86e2ff414d34e66725b05118bf10/936144c11fdee00427c3ce3cb0f87ee5770149b7/' package.json
+        sed -i -e 's/~/^/g' package.json
+        cat package.json | jq '.devDependencies."grunt-sass" = if .devDependencies."grunt-sass" | test("\\^0\\.\\d+\\.\\d+") then "^1.0.0" else .devDependencies."grunt-sass" end' > package.nn.json && mv package.nn.json package.json
+        cat package.json | jq '.devDependencies."grunt-contrib-imagemin" = if .devDependencies."grunt-contrib-imagemin" | test("\\^0\\.\\d+\\.\\d+") then "^1.0.0" else .devDependencies."grunt-contrib-imagemin" end' > package.nn.json && mv package.nn.json package.json
+        output="$(npm update --dev 2>&1)" || exit_on_error 'NPM install failed' 3 "$output"
+        echo 'Running grunt...'
+        output="$(grunt)" || exit_on_error 'Grunt failed' 3 "$output"
+    else
+        mkdir build
+        mv $(ls -A | grep -vE '^build$') build
+    fi
 fi
 
 echo "Cloning git repository..."

--- a/build-wp.sh
+++ b/build-wp.sh
@@ -52,7 +52,12 @@ exit_on_error(){
 echo "Grabbing WordPress source for $ref"
 revision=$(svn info "https://develop.svn.wordpress.org/$ref/" | grep 'Last Changed Rev' | sed 's/Last Changed Rev: //')
 if [ "tag" == $type ]; then
-    curl -sSL "https://wordpress.org/wordpress-$2.tar.gz" > /tmp/wordpress.tar.gz
+    tag_archive="https://wordpress.org/wordpress-$2.tar.gz"
+    tag_status=$(curl -Is -o /dev/null -w "%{http_code}\n" $tag_archive);
+    if [ "200" != $tag_status ]; then
+        exit_on_error "Tag $2 does not have an archive yet!" 5
+    fi
+    curl -sSL $tag_archive > /tmp/wordpress.tar.gz
     pushd /tmp
     tar -xzf wordpress.tar.gz
     mkdir -p wp/build

--- a/build-wp.sh
+++ b/build-wp.sh
@@ -50,9 +50,9 @@ exit_on_error(){
 }
 
 echo "Grabbing WordPress source for $ref"
+revision=$(svn info "https://develop.svn.wordpress.org/$ref/" | grep 'Last Changed Rev' | sed 's/Last Changed Rev: //')
 if [ "tag" == $type ]; then
 else
-revision=$(svn info "https://develop.svn.wordpress.org/$ref/" | grep 'Last Changed Rev' | sed 's/Last Changed Rev: //')
 svn export --ignore-externals "https://develop.svn.wordpress.org/$ref/" /tmp/wp/ > /dev/null 2>&1
 
 pushd /tmp/wp/

--- a/build-wp.sh
+++ b/build-wp.sh
@@ -52,6 +52,11 @@ exit_on_error(){
 echo "Grabbing WordPress source for $ref"
 revision=$(svn info "https://develop.svn.wordpress.org/$ref/" | grep 'Last Changed Rev' | sed 's/Last Changed Rev: //')
 if [ "tag" == $type ]; then
+    curl -sSL "https://wordpress.org/wordpress-$2.tar.gz" > /tmp/wordpress.tar.gz
+    pushd /tmp
+    tar -xzf wordpress.tar.gz
+    mkdir -p wp/build
+    mv wordpress/* wp/build/
 else
     svn export --ignore-externals "https://develop.svn.wordpress.org/$ref/" /tmp/wp/ > /dev/null 2>&1
 


### PR DESCRIPTION
It's a lot simpler to do it this way for releases that don't _need_ grunt. This will generate packages that also pass checksum verification.